### PR TITLE
Add storage and check valid date range

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
@@ -35,7 +35,9 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
         EventName eventName = ParserUtil.parseEventName(argMultimap.getValue(PREFIX_EVENT_NAME).get());
         DateTime startDatetime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_START_DATE_TIME).get());
         DateTime endDatetime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_END_DATE_TIME).get());
-
+        if (!DateTime.isValidDateRange(startDatetime.toString(), endDatetime.toString())) {
+            throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
+        }
         Event event = new Event(eventName, startDatetime, endDatetime);
 
         return new AddEventCommand(event);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -111,6 +111,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public ObservableList<Event> getEventList() {
+        return events.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
 
 /**
@@ -13,5 +14,5 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
-
+    ObservableList<Event> getEventList();
 }

--- a/src/main/java/seedu/address/model/event/DateTime.java
+++ b/src/main/java/seedu/address/model/event/DateTime.java
@@ -39,6 +39,19 @@ public class DateTime {
         }
     }
 
+    /**
+     * Returns true if a valid startDate is earlier than or equal to a valid endDate.
+     */
+    public static boolean isValidDateRange(String startDate, String endDate) {
+        if (!isValidDateTime(startDate) || !isValidDateTime(endDate)) {
+            return false;
+        }
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+        LocalDateTime startDateTime = LocalDateTime.parse(startDate, formatter);
+        LocalDateTime endDateTime = LocalDateTime.parse(endDate, formatter);
+        return startDateTime.equals(endDateTime) || startDateTime.isBefore(endDateTime);
+    }
+
     @Override
     public String toString() {
         return dateTime;

--- a/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
@@ -1,0 +1,2 @@
+package seedu.address.storage;public class JsonAdaptedEvent {
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
@@ -1,2 +1,66 @@
-package seedu.address.storage;public class JsonAdaptedEvent {
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.event.DateTime;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventName;
+
+
+/**
+ * Jackson-friendly version of {@link Event}.
+ */
+class JsonAdaptedEvent {
+
+    private final String eventName;
+    private final String startDateTime;
+    private final String endDateTime;
+
+    /**
+     * Constructs a {@code JsonAdaptedEvent} with the given {@code eventName}, {@code startDateTime}
+     * and {@code endDateTime}.
+     */
+    @JsonCreator
+    public JsonAdaptedEvent(@JsonProperty("eventName") String eventName,
+                            @JsonProperty("startDateTime") String startDateTime,
+                            @JsonProperty("endDateTime") String endDateTime) {
+        this.eventName = eventName;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+    }
+
+    /**
+     * Converts a given {@code Event} into this class for Jackson use.
+     */
+    public JsonAdaptedEvent(Event source) {
+
+        eventName = source.getName().toString();
+        startDateTime = source.getStartDateTime().toString();
+        endDateTime = source.getEndDateTime().toString();
+
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted event object into the model's {@code Event} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted event.
+     */
+    public Event toModelType() throws IllegalValueException {
+        if (!EventName.isValidName(eventName)) {
+            throw new IllegalValueException(EventName.MESSAGE_CONSTRAINTS);
+        }
+        if (!DateTime.isValidDateTime(startDateTime) || !DateTime.isValidDateTime(endDateTime)) {
+            throw new IllegalValueException(DateTime.MESSAGE_CONSTRAINTS);
+        }
+        if (!DateTime.isValidDateRange(startDateTime, endDateTime)) {
+            throw new IllegalValueException(DateTime.MESSAGE_CONSTRAINTS);
+        }
+        EventName nameOfEvent = new EventName(eventName);
+        DateTime dateOfStart = new DateTime(startDateTime);
+        DateTime dateOfEnd = new DateTime(endDateTime);
+        return new Event(nameOfEvent, dateOfStart, dateOfEnd);
+    }
+
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
 
 /**
@@ -20,15 +21,19 @@ import seedu.address.model.person.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_EVENT = "Events list contains duplicate event(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedEvent> events = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                       @JsonProperty("events") List<JsonAdaptedEvent> events) {
         this.persons.addAll(persons);
+        this.events.addAll(events);
     }
 
     /**
@@ -38,6 +43,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        events.addAll(source.getEventList().stream().map(JsonAdaptedEvent::new).collect(Collectors.toList()));
     }
 
     /**
@@ -53,6 +59,13 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             addressBook.addPerson(person);
+        }
+        for (JsonAdaptedEvent jsonAdaptedEvent : events) {
+            Event event = jsonAdaptedEvent.toModelType();
+            if (addressBook.hasEvent(event)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_EVENT);
+            }
+            addressBook.addEvent(event);
         }
         return addressBook;
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -10,5 +10,6 @@
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street"
-  } ]
+  } ],
+  "events" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -4,5 +4,6 @@
     "phone": "9482424",
     "email": "invalid@email!3e",
     "address": "4th street"
-  } ]
+  } ],
+  "events" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -5,5 +5,13 @@
     "email": "invalid@email!3e",
     "address": "4th street"
   } ],
-  "events" : [ ]
+  "events" : [ {
+    "eventName" : "Wedding Dinner",
+    "startDateTime" : "01-05-2023 17:00",
+    "endDateTime" : "01-05-2023 21:00"
+  }, {
+    "eventName" : "Wedding Dinner",
+    "startDateTime" : "01-05-2023 17:00",
+    "endDateTime" : "01-05-2023 21:00"
+  } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -43,5 +43,9 @@
     "address" : "4th street",
     "tagged" : [ ]
   } ],
-  "events" : [ ]
+  "events" : [ {
+    "eventName" : "Wedding Dinner",
+    "startDateTime" : "01-05-2023 17:00",
+    "endDateTime" : "01-05-2023 21:00"
+  } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -42,5 +42,6 @@
     "email" : "anna@example.com",
     "address" : "4th street",
     "tagged" : [ ]
-  } ]
+  } ],
+  "events" : [ ]
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -10,7 +10,10 @@ import static seedu.address.testutil.TypicalEvents.CARNIVAL;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -10,15 +10,13 @@ import static seedu.address.testutil.TypicalEvents.CARNIVAL;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -50,7 +48,8 @@ public class AddressBookTest {
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
-        AddressBookStub newData = new AddressBookStub(newPersons);
+        List<Event> newEvent = Arrays.asList(CARNIVAL);
+        AddressBookStub newData = new AddressBookStub(newPersons, newEvent);
 
         assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
     }
@@ -105,14 +104,21 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final ObservableList<Event> events = FXCollections.observableArrayList();
 
-        AddressBookStub(Collection<Person> persons) {
+        AddressBookStub(Collection<Person> persons, Collection<Event> events) {
             this.persons.setAll(persons);
+            this.events.setAll(events);
         }
 
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Event> getEventList() {
+            return events;
         }
     }
 }

--- a/src/test/java/seedu/address/model/event/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/event/DateTimeTest.java
@@ -34,4 +34,18 @@ public class DateTimeTest {
         // valid date time
         assertTrue(DateTime.isValidDateTime("03-02-2020 20:40"));
     }
+
+    @Test
+    public void isValidDateRange() {
+        // invalid date time range
+        assertFalse(DateTime.isValidDateRange("", "")); // empty string
+        assertFalse(DateTime.isValidDateRange(" ", " ")); // spaces only
+        assertFalse(DateTime.isValidDateRange("02-02-2023 22:20", "01-02-2023 22:20")); // one-day difference
+        assertFalse(DateTime.isValidDateRange("02-02-2023 22:20", "02-02-2023 22:19")); // one-minute difference
+
+        // valid date time range
+        assertTrue(DateTime.isValidDateRange("02-02-2023 22:20", "02-02-2023 22:20")); // accept same date
+        assertTrue(DateTime.isValidDateRange("01-02-2023 22:20", "02-02-2023 22:20")); // one-day difference
+        assertTrue(DateTime.isValidDateRange("02-02-2023 22:19", "02-02-2023 22:20")); // one-minute difference
+    }
 }

--- a/src/test/java/seedu/address/model/event/EventNameTest.java
+++ b/src/test/java/seedu/address/model/event/EventNameTest.java
@@ -28,6 +28,8 @@ public class EventNameTest {
         assertFalse(EventName.isValidName(" ")); // spaces only
         assertFalse(EventName.isValidName("!!")); // only non-alphanumeric characters
         assertFalse(EventName.isValidName("!EFG Concert!")); // starts with non-alphanumeric character
+        assertFalse(EventName.isValidName("小明's Birthday"));
+        assertFalse(EventName.isValidName("Graduation Ceremony for シャオ・ミン"));
 
         // valid name
         assertTrue(EventName.isValidName("sports day")); // alphabets only

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -1,0 +1,2 @@
+package seedu.address.storage;public class JsonAdaptedEventTest {
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -2,10 +2,10 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalEvents.WEDDING_DINNER;
+import static seedu.address.testutil.TypicalEvents.BIRTHDAY_PARTY;
 import static seedu.address.testutil.TypicalEvents.CARNIVAL;
 import static seedu.address.testutil.TypicalEvents.SPORTS_DAY;
-import static seedu.address.testutil.TypicalEvents.BIRTHDAY_PARTY;
+import static seedu.address.testutil.TypicalEvents.WEDDING_DINNER;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -1,15 +1,15 @@
 package seedu.address.storage;
 
-        import static org.junit.jupiter.api.Assertions.assertEquals;
-        import static seedu.address.testutil.Assert.assertThrows;
-        import static seedu.address.testutil.TypicalEvents.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalEvents.*;
 
-        import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Test;
 
-        import seedu.address.commons.exceptions.IllegalValueException;
-        import seedu.address.model.event.DateTime;
-        import seedu.address.model.event.Event;
-        import seedu.address.model.event.EventName;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.event.DateTime;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventName;
 
 public class JsonAdaptedEventTest {
     private static final Event INVALID_EVENT_DATETIME = new Event(

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -1,2 +1,45 @@
-package seedu.address.storage;public class JsonAdaptedEventTest {
+package seedu.address.storage;
+
+        import static org.junit.jupiter.api.Assertions.assertEquals;
+        import static seedu.address.testutil.Assert.assertThrows;
+        import static seedu.address.testutil.TypicalEvents.*;
+
+        import org.junit.jupiter.api.Test;
+
+        import seedu.address.commons.exceptions.IllegalValueException;
+        import seedu.address.model.event.DateTime;
+        import seedu.address.model.event.Event;
+        import seedu.address.model.event.EventName;
+
+public class JsonAdaptedEventTest {
+    private static final Event INVALID_EVENT_DATETIME = new Event(
+            new EventName("Dinner"), new DateTime("02-02-2023 17:00"), new DateTime("01-02-2023 17:00"));
+
+    private static final Event VALID_EVENT_WITH_SAME_DATETIME = new Event(
+            new EventName("Same date range"), new DateTime("02-02-2023 17:00"), new DateTime("02-02-2023 17:00"));
+
+    @Test
+    public void toModelType_validEventDetails_returnsEvent() throws Exception {
+        JsonAdaptedEvent event1 = new JsonAdaptedEvent(WEDDING_DINNER);
+        assertEquals(WEDDING_DINNER, event1.toModelType());
+        JsonAdaptedEvent event2 = new JsonAdaptedEvent(CARNIVAL);
+        assertEquals(CARNIVAL, event2.toModelType());
+        JsonAdaptedEvent event3 = new JsonAdaptedEvent(SPORTS_DAY);
+        assertEquals(SPORTS_DAY, event3.toModelType());
+        JsonAdaptedEvent event4 = new JsonAdaptedEvent(BIRTHDAY_PARTY);
+        assertEquals(BIRTHDAY_PARTY, event4.toModelType());
+    }
+
+    @Test
+    public void toModelType_validEventWithIdenticalDates_throwsIllegalValueException() throws Exception {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(VALID_EVENT_WITH_SAME_DATETIME);
+        assertEquals(VALID_EVENT_WITH_SAME_DATETIME, event.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidEventDates_throwsIllegalValueException() {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(INVALID_EVENT_DATETIME);
+        String expectedMessage = DateTime.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+    }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -21,8 +21,13 @@ public class JsonAdaptedEventTest {
     private static final Event VALID_EVENT_WITH_SAME_DATETIME = new Event(
             new EventName("Same date range"), new DateTime("02-02-2023 17:00"), new DateTime("02-02-2023 17:00"));
 
+    private static final String INVALID_EVENT_NAME = "小明 21'st Birthday";
+    private static final String VALID_EVENT_NAME = "Xiao Ming 21'st Birthday";
+    private static final String INVALID_START_DATETIME = "50-02-2023 17:00";
+    private static final String INVALID_END_DATETIME = "90-13-1023 17:00";
+
     @Test
-    public void toModelType_validEventDetails_returnsEvent() throws Exception {
+    public void toModelType_validEventObject_returnsEvent() throws Exception {
         JsonAdaptedEvent event1 = new JsonAdaptedEvent(WEDDING_DINNER);
         assertEquals(WEDDING_DINNER, event1.toModelType());
         JsonAdaptedEvent event2 = new JsonAdaptedEvent(CARNIVAL);
@@ -34,14 +39,46 @@ public class JsonAdaptedEventTest {
     }
 
     @Test
-    public void toModelType_validEventWithIdenticalDates_throwsIllegalValueException() throws Exception {
+    public void toModelType_validEventDetails_returnsEvent() throws Exception {
+        JsonAdaptedEvent event1 = new JsonAdaptedEvent(WEDDING_DINNER.getName().toString(),
+                WEDDING_DINNER.getStartDateTime().toString(), WEDDING_DINNER.getEndDateTime().toString());
+        assertEquals(WEDDING_DINNER, event1.toModelType());
+        JsonAdaptedEvent event2 = new JsonAdaptedEvent(CARNIVAL.getName().toString(),
+                CARNIVAL.getStartDateTime().toString(), CARNIVAL.getEndDateTime().toString());
+        assertEquals(CARNIVAL, event2.toModelType());
+        JsonAdaptedEvent event3 = new JsonAdaptedEvent(SPORTS_DAY.getName().toString(),
+                SPORTS_DAY.getStartDateTime().toString(), SPORTS_DAY.getEndDateTime().toString());
+        assertEquals(SPORTS_DAY, event3.toModelType());
+        JsonAdaptedEvent event4 = new JsonAdaptedEvent(BIRTHDAY_PARTY.getName().toString(),
+                BIRTHDAY_PARTY.getStartDateTime().toString(), BIRTHDAY_PARTY.getEndDateTime().toString());
+        assertEquals(BIRTHDAY_PARTY, event4.toModelType());
+    }
+
+    @Test
+    public void toModelType_validEventWithIdenticalDates_returnsEvent() throws Exception {
         JsonAdaptedEvent event = new JsonAdaptedEvent(VALID_EVENT_WITH_SAME_DATETIME);
         assertEquals(VALID_EVENT_WITH_SAME_DATETIME, event.toModelType());
     }
 
     @Test
-    public void toModelType_invalidEventDates_throwsIllegalValueException() {
+    public void toModelType_invalidEventDateRange_throwsIllegalValueException() {
         JsonAdaptedEvent event = new JsonAdaptedEvent(INVALID_EVENT_DATETIME);
+        String expectedMessage = DateTime.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidEventName_throwsIllegalValueException() {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(INVALID_EVENT_NAME,
+                WEDDING_DINNER.getStartDateTime().toString(), WEDDING_DINNER.getEndDateTime().toString());
+        String expectedMessage = EventName.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDateFormat_throwsIllegalValueException() {
+        JsonAdaptedEvent event = new JsonAdaptedEvent(VALID_EVENT_NAME,
+                INVALID_START_DATETIME, INVALID_END_DATETIME);
         String expectedMessage = DateTime.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -2,7 +2,10 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalEvents.*;
+import static seedu.address.testutil.TypicalEvents.WEDDING_DINNER;
+import static seedu.address.testutil.TypicalEvents.CARNIVAL;
+import static seedu.address.testutil.TypicalEvents.SPORTS_DAY;
+import static seedu.address.testutil.TypicalEvents.BIRTHDAY_PARTY;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Add JSON storage and enforce valid date range

- This commit adds support for JSON for events.
- This commit enforces valid date range for the start and end date to be entered.
- System will feedback to user if the start date is earlier than the end date. Identical dates are allowed in this commit.
- Added additional tests in EventNameTest class with additional checks for foreign characters.
- Added Tests associated with JSON files.
- Edited existing JSON files used for testing of JSON storage.

As of this iteration, addevent is not able to:
- Detect duplicate events.
- Display events stored in UI.