### PR TITLE
Add editevent command and its test cases

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -151,7 +151,7 @@ Examples:
 
 Adds a new event with the given event name, start date time, and end date time.
 
-Format: `addevent ev/EVENT from/DATETIME to/DATETIME`
+Format: `addevent ev/EVENT_NAME from/DATETIME to/DATETIME`
 
 * Event name can be a combination of alphanumeric and punctuations with spaces.
 * Event name must begin with alphanumeric.
@@ -177,14 +177,27 @@ Examples:
 
 Deletes the specified event from the event list and deletes all occurences of the event tied to persons in the address book, if any.
 
-Format: `delevent EVENTINDEX`
+Format: `delevent EVENT_INDEX`
 
-* Deletes the event at the specified `EVENTINDEX` and all occurences of the event tied to persons in the address book, if any.
+* Deletes the event at the specified `EVENT_INDEX` and all occurences of the event tied to persons in the address book, if any.
 * The event index refers to the index number shown in the displayed event list.
 * The event index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
 * `listevent` followed by `delevent 2` deletes the 2nd event in the event list and all occurences of the 2nd event tied to persons in the address book, if any.
+
+### Editing an event : `editevent`
+
+Edits an existing event in the address book.
+
+Format: `editevent EVENT_INDEX [ev/EVENT_NAME] [from/DATETIME] [to/DATETIME]`
+
+* Edits the event at the specified `EVENT_INDEX`. The index refers to the index number shown in the displayed event list. The index **must be a positive integer** 1, 2, 3, …​
+* At least one of the optional fields must be provided.
+* Existing values will be updated to the input values.
+
+Examples:
+*  `editevent 1 ev/Birthday Party from/17-07-2023 12:00` Edits the event name and start datetime of the 1st event to be `Birthday Party` and `17-07-2023 12:00` respectively.
 
 ### Clearing all entries : `clear`
 
@@ -227,12 +240,13 @@ _Details coming soon ..._
 
 Action | Format, Examples
 --------|------------------
-**Add Contact** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]… [ev/EVENTINDEX] …​` <br> e.g., `add n/Alex Yeoh p/89028392 e/alex@email.com a/Blk 142 Apple Street 23 ev/1`
-**Add Event** | `addevent ev/EVENT from/DATETIME to/DATETIME` <br> e.g., `addevent ev/Wedding Dinner from/01-05-2023 17:00 to/01-05-2023 21:00`
+**Add Contact** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]… [ev/EVENT_INDEX] …​` <br> e.g., `add n/Alex Yeoh p/89028392 e/alex@email.com a/Blk 142 Apple Street 23 ev/1`
+**Add Event** | `addevent ev/EVENT_NAME from/DATETIME to/DATETIME` <br> e.g., `addevent ev/Wedding Dinner from/01-05-2023 17:00 to/01-05-2023 21:00`
 **Clear** | `clear`
 **Delete Contact** | `delete INDEX`<br> e.g., `delete 3`
-**Delete Event** | `delevent EVENTINDEX` <br> e.g., `delevent 2`
+**Delete Event** | `delevent EVENT_INDEX` <br> e.g., `delevent 2`
 **Edit Contact** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit Event** | `editevent EVENT_INDEX [ev/EVENT_NAME] [from/DATETIME] [to/DATETIME]​`<br> e.g.,`editevent 1 ev/Birthday Party from/17-07-2023 12:00`
 **List Contact** | `list`
 **List Event** | `listevent`
 **Help** | `help`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -175,16 +175,16 @@ Examples:
 
 ### Deleting an event : `delevent`
 
-Deletes the specified event from the event list and deletes all occurences of the event tied to persons in the address book, if any.
+Deletes the specified event from the event list and deletes all occurrences of the event tied to persons in the address book, if any.
 
 Format: `delevent EVENT_INDEX`
 
-* Deletes the event at the specified `EVENT_INDEX` and all occurences of the event tied to persons in the address book, if any.
+* Deletes the event at the specified `EVENT_INDEX` and all occurrences of the event tied to persons in the address book, if any.
 * The event index refers to the index number shown in the displayed event list.
 * The event index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `listevent` followed by `delevent 2` deletes the 2nd event in the event list and all occurences of the 2nd event tied to persons in the address book, if any.
+* `listevent` followed by `delevent 2` deletes the 2nd event in the event list and all occurrences of the 2nd event tied to persons in the address book, if any.
 
 ### Editing an event : `editevent`
 
@@ -192,9 +192,11 @@ Edits an existing event in the address book.
 
 Format: `editevent EVENT_INDEX [ev/EVENT_NAME] [from/DATETIME] [to/DATETIME]`
 
-* Edits the event at the specified `EVENT_INDEX`. The index refers to the index number shown in the displayed event list. The index **must be a positive integer** 1, 2, 3, …​
+* Edits the event at the specified `EVENT_INDEX` and edits the relevant event tag tied to all persons in the address book.
+* The event index refers to the index number shown in the displayed event list. The event index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
+* Edits will not allow start date time to be after the end date time.
 
 Examples:
 *  `editevent 1 ev/Birthday Party from/17-07-2023 12:00` Edits the event name and start datetime of the 1st event to be `Birthday Party` and `17-07-2023 12:00` respectively.

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -38,8 +38,8 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_EVENT_SET + " 1"
-            + PREFIX_EVENT_SET + " 2";
+            + PREFIX_EVENT_SET + "1 "
+            + PREFIX_EVENT_SET + "2 ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -35,6 +35,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
+            + "Event tags are cumulative."
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -1,0 +1,189 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE_TIME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EVENTS;
+
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.DateTime;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventName;
+
+/**
+ * Edits the details of an existing event in the address book.
+ */
+public class EditEventCommand extends Command {
+
+    public static final String COMMAND_WORD = "editevent";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the event identified "
+            + "by the index number used in the displayed event list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_EVENT_NAME + "NAME] "
+            + "[" + PREFIX_START_DATE_TIME + "START DATETIME] "
+            + "[" + PREFIX_END_DATE_TIME + "END DATETIME]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_EVENT_NAME + "Birthday Party "
+            + PREFIX_START_DATE_TIME + "16-07-2023 12:00 ";
+
+    public static final String MESSAGE_EDIT_EVENT_SUCCESS = "Edited Event: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the address book.";
+
+    private final Index index;
+    private final EditEventDescriptor editEventDescriptor;
+
+    /**
+     * @param index of the event in the filtered event list to edit
+     * @param editEventDescriptor details to edit the event with
+     */
+    public EditEventCommand(Index index, EditEventDescriptor editEventDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editEventDescriptor);
+
+        this.index = index;
+        this.editEventDescriptor = new EditEventDescriptor(editEventDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Event> lastShownEventList = model.getFilteredEventList();
+
+        if (index.getZeroBased() >= lastShownEventList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+        }
+
+        Event eventToEdit = lastShownEventList.get(index.getZeroBased());
+        Event editedEvent = createEditedEvent(eventToEdit, editEventDescriptor);
+
+        if (!eventToEdit.isSameEvent(editedEvent) && model.hasEvent(editedEvent)) {
+            throw new CommandException(MESSAGE_DUPLICATE_EVENT);
+        }
+
+        model.setEvent(eventToEdit, editedEvent);
+        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
+        model.setEventFromPersonList(eventToEdit, editedEvent);
+        return new CommandResult(String.format(MESSAGE_EDIT_EVENT_SUCCESS, editedEvent));
+    }
+
+    /**
+     * Creates and returns a {@code Event} with the details of {@code eventToEdit}
+     * edited with {@code editEventDescriptor}.
+     */
+    private static Event createEditedEvent(Event eventToEdit, EditEventDescriptor editEventDescriptor)
+            throws CommandException {
+        assert eventToEdit != null;
+
+        EventName updatedEventName = editEventDescriptor.getEventName().orElse(eventToEdit.getName());
+        DateTime updatedStartDateTime = editEventDescriptor.getStartDateTime().orElse(eventToEdit.getStartDateTime());
+        DateTime updatedEndDateTime = editEventDescriptor.getEndDateTime().orElse(eventToEdit.getEndDateTime());
+
+        if (!DateTime.isValidDateRange(updatedStartDateTime.toString(), updatedEndDateTime.toString())) {
+            throw new CommandException(DateTime.MESSAGE_CONSTRAINTS);
+        }
+
+        return new Event(updatedEventName, updatedStartDateTime, updatedEndDateTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditEventCommand)) {
+            return false;
+        }
+
+        // state check
+        EditEventCommand e = (EditEventCommand) other;
+        return index.equals(e.index)
+                && editEventDescriptor.equals(e.editEventDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the event with. Each non-empty field value will replace the
+     * corresponding field value of the event.
+     */
+    public static class EditEventDescriptor {
+        private EventName eventName;
+        private DateTime startDateTime;
+        private DateTime endDateTime;
+
+        public EditEventDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditEventDescriptor(EditEventDescriptor toCopy) {
+            setEventName(toCopy.eventName);
+            setStartDateTime(toCopy.startDateTime);
+            setEndDateTime(toCopy.endDateTime);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(eventName, startDateTime, endDateTime);
+        }
+
+        public void setEventName(EventName eventName) {
+            this.eventName = eventName;
+        }
+
+        public Optional<EventName> getEventName() {
+            return Optional.ofNullable(eventName);
+        }
+
+        public void setStartDateTime(DateTime startDateTime) {
+            this.startDateTime = startDateTime;
+        }
+
+        public Optional<DateTime> getStartDateTime() {
+            return Optional.ofNullable(startDateTime);
+        }
+
+        public void setEndDateTime(DateTime endDateTime) {
+            this.endDateTime = endDateTime;
+        }
+
+        public Optional<DateTime> getEndDateTime() {
+            return Optional.ofNullable(endDateTime);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditEventDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditEventDescriptor e = (EditEventDescriptor) other;
+
+            return getEventName().equals(e.getEventName())
+                    && getStartDateTime().equals(e.getStartDateTime())
+                    && getEndDateTime().equals(e.getEndDateTime());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DelEventCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditEventCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -52,6 +53,9 @@ public class AddressBookParser {
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
+
+        case EditEventCommand.COMMAND_WORD:
+            return new EditEventCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE_TIME;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditEventCommand;
+import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditCommand object
+ */
+public class EditEventCommandParser implements Parser<EditEventCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditEventCommand
+     * and returns an EditEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditEventCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_EVENT_NAME, PREFIX_START_DATE_TIME, PREFIX_END_DATE_TIME);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEventCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditEventDescriptor editEventDescriptor = new EditEventDescriptor();
+        if (argMultimap.getValue(PREFIX_EVENT_NAME).isPresent()) {
+            editEventDescriptor.setEventName(ParserUtil.parseEventName(argMultimap
+                    .getValue(PREFIX_EVENT_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_START_DATE_TIME).isPresent()) {
+            editEventDescriptor.setStartDateTime(ParserUtil.parseDateTime(argMultimap
+                    .getValue(PREFIX_START_DATE_TIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_END_DATE_TIME).isPresent()) {
+            editEventDescriptor.setEndDateTime(ParserUtil.parseDateTime(argMultimap
+                    .getValue(PREFIX_END_DATE_TIME).get()));
+        }
+
+        if (!editEventDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditEventCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditEventCommand(index, editEventDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -160,7 +160,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Replaces the given event {@code target} in the list with {@code editedEvent}.
+     * Replaces the given event {@code target} in the event set of all persons in address book with {@code editedEvent}.
      * {@code target} must exist in the address book.
      * The event identity of {@code editedEvent} must not be the same as another existing event in the address book.
      */
@@ -187,9 +187,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Replaces the given person {@code target} in the list with {@code editedPerson}.
+     * Replaces the given event {@code target} in the list with {@code editedEvent}.
      * {@code target} must exist in the address book.
-     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     * The event identity of {@code editedEvent} must not be the same as another existing event in the address book.
      */
     public void setEvent(Event target, Event editedEvent) {
         requireNonNull(editedEvent);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.HashSet;
 import java.util.List;
@@ -156,6 +157,44 @@ public class AddressBook implements ReadOnlyAddressBook {
                 persons.setPerson(personToCheck, editedPerson);
             }
         }
+    }
+
+    /**
+     * Replaces the given event {@code target} in the list with {@code editedEvent}.
+     * {@code target} must exist in the address book.
+     * The event identity of {@code editedEvent} must not be the same as another existing event in the address book.
+     */
+    public void setEventFromPersonList(Event target, Event editedEvent) {
+        requireAllNonNull(target, editedEvent);
+        for (Person personToCheck: getPersonList()) {
+            if (personToCheck.getEventSet().contains(target)) {
+                // Person needs to have the event tag replaced
+                Set<Event> editedEventSet = new HashSet<>();
+                for (Event eventToCheck : personToCheck.getEventSet()) {
+                    if (!eventToCheck.equals(target)) {
+                        // Event tags that are not edited will not be removed
+                        editedEventSet.add(eventToCheck);
+                    } else {
+                        // Event tag that is being edited will be replaced
+                        editedEventSet.add(editedEvent);
+                    }
+                }
+                Person editedPerson = new Person(personToCheck.getName(), personToCheck.getPhone(),
+                        personToCheck.getEmail(), personToCheck.getAddress(), editedEventSet);
+                persons.setPerson(personToCheck, editedPerson);
+            }
+        }
+    }
+
+    /**
+     * Replaces the given person {@code target} in the list with {@code editedPerson}.
+     * {@code target} must exist in the address book.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     */
+    public void setEvent(Event target, Event editedEvent) {
+        requireNonNull(editedEvent);
+
+        events.setEvent(target, editedEvent);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -86,6 +86,13 @@ public interface Model {
      */
     void deleteEventFromPersonList(Event eventToDelete);
 
+    /**
+     * Replaces the given event {@code target} with {@code editedEvent} for all persons in the list.
+     * {@code target} must exist in the address book.
+     * The person identity of {@code editedEvent} must not be the same as another existing event in the address book.
+     */
+    void setEventFromPersonList(Event target, Event editedEvent);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
@@ -111,6 +118,13 @@ public interface Model {
      * The event must exist in the address book.
      */
     void deleteEvent(Event event);
+
+    /**
+     * Replaces the given event {@code target} with {@code editedEvent}.
+     * {@code target} must exist in the address book.
+     * The event identity of {@code editedEvent} must not be the same as another existing event in the address book.
+     */
+    void setEvent(Event target, Event editedEvent);
 
     /** Returns an unmodifiable view of the filtered event list */
     ObservableList<Event> getFilteredEventList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -121,6 +121,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setEventFromPersonList(Event target, Event editedEvent) {
+        requireAllNonNull(target, editedEvent);
+        addressBook.setEventFromPersonList(target, editedEvent);
+    }
+
+    @Override
     public boolean hasEvent(Event event) {
         requireNonNull(event);
         return addressBook.hasEvent(event);
@@ -135,6 +141,13 @@ public class ModelManager implements Model {
     @Override
     public void deleteEvent(Event target) {
         addressBook.removeEvent(target);
+    }
+
+    @Override
+    public void setEvent(Event target, Event editedEvent) {
+        requireAllNonNull(target, editedEvent);
+
+        addressBook.setEvent(target, editedEvent);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -45,6 +45,26 @@ public class UniqueEventList implements Iterable<Event> {
         internalList.add(toAdd);
     }
 
+    /**
+     * Replaces the event {@code target} in the list with {@code editedEvent}.
+     * {@code target} must exist in the list.
+     * The event identity of {@code editedEvent} must not be the same as another existing event in the list.
+     */
+    public void setEvent(Event target, Event editedEvent) {
+        requireAllNonNull(target, editedEvent);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new EventNotFoundException();
+        }
+
+        if (!target.isSameEvent(editedEvent) && contains(editedEvent)) {
+            throw new DuplicateEventException();
+        }
+
+        internalList.set(index, editedEvent);
+    }
+
     public void setEvents(UniqueEventList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -203,6 +203,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setEventFromPersonList(Event target, Event editedEvent) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -224,6 +229,11 @@ public class AddCommandTest {
 
         @Override
         public void deleteEvent(Event target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setEvent(Event target, Event editedEvent) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
@@ -147,6 +147,11 @@ public class AddEventCommandTest {
         }
 
         @Override
+        public void setEventFromPersonList(Event target, Event editedEvent) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -168,6 +173,11 @@ public class AddEventCommandTest {
 
         @Override
         public void deleteEvent(Event target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setEvent(Event target, Event editedEvent) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -26,6 +26,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventNameContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.EditEventDescriptorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -95,6 +96,8 @@ public class CommandTestUtil {
 
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditEventCommand.EditEventDescriptor DESC_CARNIVAL;
+    public static final EditEventCommand.EditEventDescriptor DESC_SPORTS_DAY;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -103,6 +106,12 @@ public class CommandTestUtil {
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withEventSet(SPORTS_DAY).build();
+        DESC_CARNIVAL = new EditEventDescriptorBuilder().withEventName(VALID_EVENT_NAME_CARNIVAL)
+                .withStartDateTime(VALID_START_DATE_TIME_CARNIVAL)
+                .withEndDateTime(VALID_END_DATE_TIME_CARNIVAL).build();
+        DESC_SPORTS_DAY = new EditEventDescriptorBuilder().withEventName(VALID_EVENT_NAME_SPORTS_DAY)
+                .withStartDateTime(VALID_START_DATE_TIME_SPORTS_DAY)
+                .withEndDateTime(VALID_END_DATE_TIME_SPORTS_DAY).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -32,6 +32,7 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
+
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */

--- a/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
@@ -1,0 +1,195 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_SPORTS_DAY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_TIME_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_NAME_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showEventAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.DateTime;
+import seedu.address.model.event.Event;
+import seedu.address.testutil.EditEventDescriptorBuilder;
+import seedu.address.testutil.EventBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditEventCommand.
+ */
+public class EditEventCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Event editedEvent = new EventBuilder().build();
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder(editedEvent).build();
+        EditEventCommand editEventCommand = new EditEventCommand(INDEX_FIRST_EVENT, descriptor);
+
+        String expectedMessage = String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, editedEvent);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setEvent(model.getFilteredEventList().get(0), editedEvent);
+        expectedModel.setEventFromPersonList(model.getFilteredEventList().get(0), editedEvent);
+
+        assertCommandSuccess(editEventCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastEvent = Index.fromOneBased(model.getFilteredEventList().size());
+        Event lastEvent = model.getFilteredEventList().get(indexLastEvent.getZeroBased());
+
+        EventBuilder eventInList = new EventBuilder(lastEvent);
+        Event editedEvent = eventInList.withName(VALID_EVENT_NAME_CARNIVAL)
+                .withStartDateTime(VALID_START_DATE_TIME_CARNIVAL)
+                .withEndDateTime(VALID_END_DATE_TIME_CARNIVAL).build();
+
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder().withEventName(VALID_EVENT_NAME_CARNIVAL)
+                .withStartDateTime(VALID_START_DATE_TIME_CARNIVAL)
+                .withEndDateTime(VALID_END_DATE_TIME_CARNIVAL).build();
+        EditEventCommand editEventCommand = new EditEventCommand(indexLastEvent, descriptor);
+
+        String expectedMessage = String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, editedEvent);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setEvent(lastEvent, editedEvent);
+
+        assertCommandSuccess(editEventCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditEventCommand editEventCommand = new EditEventCommand(INDEX_FIRST_EVENT, new EditEventDescriptor());
+        Event editedEvent = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+
+        String expectedMessage = String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, editedEvent);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(editEventCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showEventAtIndex(model, INDEX_FIRST_EVENT);
+
+        Event eventInFilteredList = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        Event editedEvent = new EventBuilder(eventInFilteredList).withName(VALID_EVENT_NAME_CARNIVAL).build();
+        EditEventCommand editEventCommand = new EditEventCommand(INDEX_FIRST_EVENT,
+                new EditEventDescriptorBuilder().withEventName(VALID_EVENT_NAME_CARNIVAL).build());
+
+        String expectedMessage = String.format(EditEventCommand.MESSAGE_EDIT_EVENT_SUCCESS, editedEvent);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setEvent(model.getFilteredEventList().get(0), editedEvent);
+        expectedModel.setEventFromPersonList(model.getFilteredEventList().get(0), editedEvent);
+
+        assertCommandSuccess(editEventCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateEventUnfilteredList_failure() {
+        Event firstEvent = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder(firstEvent).build();
+        EditEventCommand editEventCommand = new EditEventCommand(INDEX_SECOND_EVENT, descriptor);
+
+        assertCommandFailure(editEventCommand, model, EditEventCommand.MESSAGE_DUPLICATE_EVENT);
+    }
+
+    @Test
+    public void execute_duplicateEventFilteredList_failure() {
+        showEventAtIndex(model, INDEX_FIRST_EVENT);
+
+        // edit person in filtered list into a duplicate in address book
+        Event eventInList = model.getAddressBook().getEventList().get(INDEX_SECOND_EVENT.getZeroBased());
+        EditEventCommand editEventCommand = new EditEventCommand(INDEX_FIRST_EVENT,
+                new EditEventDescriptorBuilder(eventInList).build());
+
+        assertCommandFailure(editEventCommand, model, EditEventCommand.MESSAGE_DUPLICATE_EVENT);
+    }
+
+    @Test
+    public void execute_invalidEventIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEventList().size() + 1);
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder()
+                .withEventName(VALID_EVENT_NAME_CARNIVAL).build();
+        EditEventCommand editEventCommand = new EditEventCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editEventCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidEventIndexFilteredList_failure() {
+        showEventAtIndex(model, INDEX_FIRST_EVENT);
+        Index outOfBoundIndex = INDEX_SECOND_EVENT;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getEventList().size());
+
+        EditEventCommand editEventCommand = new EditEventCommand(outOfBoundIndex,
+                new EditEventDescriptorBuilder().withEventName(VALID_EVENT_NAME_CARNIVAL).build());
+
+        assertCommandFailure(editEventCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_startDateTimeAfterEndDateTime_failure() {
+        Event editedEvent = new EventBuilder().build();
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder(editedEvent).build();
+        EditEventCommand editEventCommand = new EditEventCommand(INDEX_FIRST_EVENT,
+                new EditEventDescriptorBuilder().withStartDateTime("30-12-2099 12:00").build());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setEvent(model.getFilteredEventList().get(0), editedEvent);
+        expectedModel.setEventFromPersonList(model.getFilteredEventList().get(0), editedEvent);
+
+        assertCommandFailure(editEventCommand, model, DateTime.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void equals() {
+        final EditEventCommand standardCommand =
+                new EditEventCommand(INDEX_FIRST_EVENT, DESC_CARNIVAL);
+
+        // same values -> returns true
+        EditEventDescriptor copyDescriptor = new EditEventDescriptor(DESC_CARNIVAL);
+        EditEventCommand commandWithSameValues =
+                new EditEventCommand(INDEX_FIRST_EVENT, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditEventCommand(INDEX_SECOND_EVENT, DESC_CARNIVAL)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditEventCommand(INDEX_FIRST_EVENT, DESC_SPORTS_DAY)));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
@@ -135,7 +135,7 @@ public class EditEventCommandTest {
     }
 
     /**
-     * Edit filtered list where index is larger than size of filtered list,
+     * Edit filtered list where the index is larger than the size of filtered list,
      * but smaller than size of address book
      */
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEventCommandTest.java
@@ -116,7 +116,7 @@ public class EditEventCommandTest {
     public void execute_duplicateEventFilteredList_failure() {
         showEventAtIndex(model, INDEX_FIRST_EVENT);
 
-        // edit person in filtered list into a duplicate in address book
+        // edit event in filtered list into a duplicate in address book
         Event eventInList = model.getAddressBook().getEventList().get(INDEX_SECOND_EVENT.getZeroBased());
         EditEventCommand editEventCommand = new EditEventCommand(INDEX_FIRST_EVENT,
                 new EditEventDescriptorBuilder(eventInList).build());

--- a/src/test/java/seedu/address/logic/commands/EditEventDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEventDescriptorTest.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_SPORTS_DAY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_TIME_SPORTS_DAY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_NAME_SPORTS_DAY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_SPORTS_DAY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
+import seedu.address.testutil.EditEventDescriptorBuilder;
+
+public class EditEventDescriptorTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        EditEventDescriptor descriptorWithSameValues = new EditEventDescriptor(DESC_CARNIVAL);
+        assertTrue(DESC_CARNIVAL.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_CARNIVAL.equals(DESC_CARNIVAL));
+
+        // null -> returns false
+        assertFalse(DESC_CARNIVAL.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_CARNIVAL.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_CARNIVAL.equals(DESC_SPORTS_DAY));
+
+        // different event name -> returns false
+        EditEventDescriptor editedCarnival = new EditEventDescriptorBuilder(DESC_CARNIVAL)
+                .withEventName(VALID_EVENT_NAME_SPORTS_DAY).build();
+        assertFalse(DESC_CARNIVAL.equals(editedCarnival));
+
+        // different start datetime -> returns false
+        editedCarnival = new EditEventDescriptorBuilder(DESC_CARNIVAL)
+                .withStartDateTime(VALID_START_DATE_TIME_SPORTS_DAY).build();
+        assertFalse(DESC_CARNIVAL.equals(editedCarnival));
+
+        // different end datetime -> returns false
+        editedCarnival = new EditEventDescriptorBuilder(DESC_CARNIVAL)
+                .withEndDateTime(VALID_END_DATE_TIME_SPORTS_DAY).build();
+        assertFalse(DESC_CARNIVAL.equals(editedCarnival));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,6 +23,8 @@ import seedu.address.logic.commands.DelEventCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditEventCommand;
+import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -32,6 +34,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Event;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.EditEventDescriptorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.EventBuilder;
 import seedu.address.testutil.EventUtil;
@@ -70,6 +73,15 @@ public class AddressBookParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor, Optional.of(INDEX_SET_NO_EVENT)), command);
+    }
+
+    @Test
+    public void parseCommand_editEvent() throws Exception {
+        Event event = new EventBuilder().build();
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder(event).build();
+        EditEventCommand command = (EditEventCommand) parser.parseCommand(EditEventCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_EVENT.getOneBased() + " " + EventUtil.getEditEventDescriptorDetails(descriptor));
+        assertEquals(new EditEventCommand(INDEX_FIRST_EVENT, descriptor), command);
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/EditEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditEventCommandParserTest.java
@@ -1,0 +1,170 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.END_DATE_TIME_DESC_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.EVENT_NAME_DESC_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.EVENT_NAME_DESC_SPORTS_DAY;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_DATE_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EVENT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_DATE_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.START_DATE_TIME_DESC_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.START_DATE_TIME_DESC_SPORTS_DAY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_TIME_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_NAME_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_NAME_SPORTS_DAY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_CARNIVAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_SPORTS_DAY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_EVENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditEventCommand;
+import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
+import seedu.address.model.event.DateTime;
+import seedu.address.model.event.EventName;
+import seedu.address.testutil.EditEventDescriptorBuilder;
+
+public class EditEventCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEventCommand.MESSAGE_USAGE);
+
+    private EditEventCommandParser parser = new EditEventCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_EVENT_NAME_CARNIVAL, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", EditEventCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + EVENT_NAME_DESC_CARNIVAL, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + EVENT_NAME_DESC_CARNIVAL, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1"
+                + INVALID_EVENT_NAME_DESC, EventName.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, "1"
+                + INVALID_START_DATE_TIME_DESC, DateTime.MESSAGE_CONSTRAINTS); // invalid start datetime
+        assertParseFailure(parser, "1"
+                + INVALID_END_DATE_TIME_DESC, DateTime.MESSAGE_CONSTRAINTS); // invalid end datetime
+
+        // invalid event name followed by valid start datetime
+        assertParseFailure(parser, "1"
+                + INVALID_EVENT_NAME_DESC + START_DATE_TIME_DESC_CARNIVAL, EventName.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, "1" + INVALID_EVENT_NAME_DESC + INVALID_START_DATE_TIME_DESC,
+                EventName.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_EVENT;
+        String userInput = targetIndex.getOneBased() + EVENT_NAME_DESC_CARNIVAL + START_DATE_TIME_DESC_CARNIVAL
+                + END_DATE_TIME_DESC_CARNIVAL;
+
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder()
+                .withEventName(VALID_EVENT_NAME_CARNIVAL)
+                .withStartDateTime(VALID_START_DATE_TIME_CARNIVAL)
+                .withEndDateTime(VALID_END_DATE_TIME_CARNIVAL).build();
+        EditEventCommand expectedCommand = new EditEventCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_EVENT;
+        String userInput = targetIndex.getOneBased() + EVENT_NAME_DESC_SPORTS_DAY
+                + START_DATE_TIME_DESC_SPORTS_DAY;
+
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder()
+                .withEventName(VALID_EVENT_NAME_SPORTS_DAY)
+                .withStartDateTime(VALID_START_DATE_TIME_SPORTS_DAY).build();
+        EditEventCommand expectedCommand = new EditEventCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // event name
+        Index targetIndex = INDEX_THIRD_EVENT;
+        String userInput = targetIndex.getOneBased() + EVENT_NAME_DESC_CARNIVAL;
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder()
+                .withEventName(VALID_EVENT_NAME_CARNIVAL).build();
+        EditEventCommand expectedCommand = new EditEventCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // start datetime
+        userInput = targetIndex.getOneBased() + START_DATE_TIME_DESC_CARNIVAL;
+        descriptor = new EditEventDescriptorBuilder().withStartDateTime(VALID_START_DATE_TIME_CARNIVAL).build();
+        expectedCommand = new EditEventCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // end datetime
+        userInput = targetIndex.getOneBased() + END_DATE_TIME_DESC_CARNIVAL;
+        descriptor = new EditEventDescriptorBuilder().withEndDateTime(VALID_END_DATE_TIME_CARNIVAL).build();
+        expectedCommand = new EditEventCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        Index targetIndex = INDEX_FIRST_EVENT;
+        String userInput = targetIndex.getOneBased() + EVENT_NAME_DESC_SPORTS_DAY
+                + EVENT_NAME_DESC_CARNIVAL
+                + START_DATE_TIME_DESC_CARNIVAL + END_DATE_TIME_DESC_CARNIVAL;
+
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder().withEventName(VALID_EVENT_NAME_CARNIVAL)
+                .withStartDateTime(VALID_START_DATE_TIME_CARNIVAL)
+                .withEndDateTime(VALID_END_DATE_TIME_CARNIVAL).build();
+        EditEventCommand expectedCommand = new EditEventCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() {
+        // no other valid values specified
+        Index targetIndex = INDEX_FIRST_EVENT;
+        String userInput = targetIndex.getOneBased() + INVALID_EVENT_NAME_DESC + EVENT_NAME_DESC_CARNIVAL;
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder()
+                .withEventName(VALID_EVENT_NAME_CARNIVAL).build();
+        EditEventCommand expectedCommand = new EditEventCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // other valid values specified
+        userInput = targetIndex.getOneBased() + START_DATE_TIME_DESC_CARNIVAL + INVALID_EVENT_NAME_DESC
+                + EVENT_NAME_DESC_CARNIVAL + END_DATE_TIME_DESC_CARNIVAL;
+        descriptor = new EditEventDescriptorBuilder().withEventName(VALID_EVENT_NAME_CARNIVAL)
+                .withStartDateTime(VALID_START_DATE_TIME_CARNIVAL)
+                .withEndDateTime(VALID_END_DATE_TIME_CARNIVAL).build();
+        expectedCommand = new EditEventCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/event/UniqueEventListTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EVENT_NAME_CARN
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_TIME_CARNIVAL;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEvents.CARNIVAL;
+import static seedu.address.testutil.TypicalEvents.SPORTS_DAY;
 import static seedu.address.testutil.TypicalEvents.WEDDING_DINNER;
 
 import java.util.ArrayList;
@@ -154,5 +155,17 @@ public class UniqueEventListTest {
     public void eventsAreUnique_uniqueEvents_returnsTrue() {
         List<Event> events = new ArrayList<>(Arrays.asList(CARNIVAL, WEDDING_DINNER));
         assertTrue(uniqueEventList.eventsAreUnique(events));
+    }
+
+    @Test
+    public void setEvent_targetEventNotInList_throwsEventNotFoundException() {
+        assertThrows(EventNotFoundException.class, () -> uniqueEventList.setEvent(CARNIVAL, CARNIVAL));
+    }
+
+    @Test
+    public void setEvent_editedEventHasNonUniqueIdentity_throwsDuplicateEventException() {
+        uniqueEventList.add(CARNIVAL);
+        uniqueEventList.add(SPORTS_DAY);
+        assertThrows(DuplicateEventException.class, () -> uniqueEventList.setEvent(CARNIVAL, SPORTS_DAY));
     }
 }

--- a/src/test/java/seedu/address/testutil/EditEventDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditEventDescriptorBuilder.java
@@ -6,7 +6,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventName;
 
 /**
- * A utility class to help with building EditPersonDescriptor objects.
+ * A utility class to help with building EditEventDescriptor objects.
  */
 public class EditEventDescriptorBuilder {
 

--- a/src/test/java/seedu/address/testutil/EditEventDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditEventDescriptorBuilder.java
@@ -31,7 +31,7 @@ public class EditEventDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code eventName} of the {@code EditPersonDescriptor} that we are building.
+     * Sets the {@code eventName} of the {@code EditEventDescriptor} that we are building.
      */
     public EditEventDescriptorBuilder withEventName(String eventName) {
         descriptor.setEventName(new EventName(eventName));

--- a/src/test/java/seedu/address/testutil/EditEventDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditEventDescriptorBuilder.java
@@ -1,0 +1,60 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
+import seedu.address.model.event.DateTime;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventName;
+
+/**
+ * A utility class to help with building EditPersonDescriptor objects.
+ */
+public class EditEventDescriptorBuilder {
+
+    private EditEventDescriptor descriptor;
+
+    public EditEventDescriptorBuilder() {
+        descriptor = new EditEventDescriptor();
+    }
+
+    public EditEventDescriptorBuilder(EditEventDescriptor descriptor) {
+        this.descriptor = new EditEventDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditEventDescriptor} with fields containing {@code event}'s details
+     */
+    public EditEventDescriptorBuilder(Event event) {
+        descriptor = new EditEventDescriptor();
+        descriptor.setEventName(event.getName());
+        descriptor.setStartDateTime(event.getStartDateTime());
+        descriptor.setEndDateTime(event.getEndDateTime());
+    }
+
+    /**
+     * Sets the {@code eventName} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditEventDescriptorBuilder withEventName(String eventName) {
+        descriptor.setEventName(new EventName(eventName));
+        return this;
+    }
+
+    /**
+     * Sets the {@code startDateTime} of the {@code EditEventDescriptor} that we are building.
+     */
+    public EditEventDescriptorBuilder withStartDateTime(String startDateTime) {
+        descriptor.setStartDateTime(new DateTime(startDateTime));
+        return this;
+    }
+
+    /**
+     * Sets the {@code endDateTime} of the {@code EditEventDescriptor} that we are building.
+     */
+    public EditEventDescriptorBuilder withEndDateTime(String endDateTime) {
+        descriptor.setEndDateTime(new DateTime(endDateTime));
+        return this;
+    }
+
+    public EditEventDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/EventUtil.java
+++ b/src/test/java/seedu/address/testutil/EventUtil.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE_TIME;
 
 import seedu.address.logic.commands.AddEventCommand;
+import seedu.address.logic.commands.EditEventCommand;
 import seedu.address.model.event.Event;
 
 /**
@@ -27,6 +28,19 @@ public class EventUtil {
         sb.append(PREFIX_EVENT_NAME + event.getName().name + " ");
         sb.append(PREFIX_START_DATE_TIME + event.getStartDateTime().dateTime + " ");
         sb.append(PREFIX_END_DATE_TIME + event.getEndDateTime().dateTime + " ");
+        return sb.toString();
+    }
+
+    /**
+     * Returns the part of command string for the given {@code EditEventDescriptor}'s details.
+     */
+    public static String getEditEventDescriptorDetails(EditEventCommand.EditEventDescriptor descriptor) {
+        StringBuilder sb = new StringBuilder();
+        descriptor.getEventName().ifPresent(eventName -> sb.append(PREFIX_EVENT_NAME).append(eventName).append(" "));
+        descriptor.getStartDateTime().ifPresent(startDateTime ->
+                sb.append(PREFIX_START_DATE_TIME).append(startDateTime).append(" "));
+        descriptor.getEndDateTime().ifPresent(endDateTime ->
+                sb.append(PREFIX_END_DATE_TIME).append(endDateTime).append(" "));
         return sb.toString();
     }
 }


### PR DESCRIPTION
This commit add editevent command and its test cases.

Note that editevent:
- Allows for user to edit an event's name, start date time, and/or start end time.
- Edits the relevant event tag tied to all persons in address book.
- Will detect end datetime < start datetime as an error if start/end datetime is edited to be of invalid range.

The UG for the editevent feature has also been added in this commit.