### PR TITLE
Add list contacts from event feature

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,6 +147,19 @@ Examples:
 * `list` followed by `delete 2` deletes the 2nd person in the address book.
 * `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
+### Listing persons from an event: `listevcontact`
+
+Shows a list of persons in the address book whose event set contains the specified event.
+
+Format: `listevcontact EVENT_INDEX`
+
+* Lists all persons from the event at the specified `EVENT_INDEX` in the address book.
+* The event index refers to the index number shown in the displayed event list.
+* The event index **must be a positive integer** 1, 2, 3, …​
+
+Examples:
+* `listevent` followed by `listevcontact 2` lists all the persons whose event set contains the 2nd event in the event list.
+
 ### Adding a new event : `addevent`
 
 Adds a new event with the given event name, start date time, and end date time.
@@ -227,14 +240,15 @@ _Details coming soon ..._
 
 Action | Format, Examples
 --------|------------------
-**Add Contact** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]… [ev/EVENTINDEX] …​` <br> e.g., `add n/Alex Yeoh p/89028392 e/alex@email.com a/Blk 142 Apple Street 23 ev/1`
+**Add Contact** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [evt/EVENT_INDEX] …​` <br> e.g., `add n/Alex Yeoh p/89028392 e/alex@email.com a/Blk 142 Apple Street 23 evt/1`
 **Add Event** | `addevent ev/EVENT from/DATETIME to/DATETIME` <br> e.g., `addevent ev/Wedding Dinner from/01-05-2023 17:00 to/01-05-2023 21:00`
 **Clear** | `clear`
 **Delete Contact** | `delete INDEX`<br> e.g., `delete 3`
 **Delete Event** | `delevent EVENTINDEX` <br> e.g., `delevent 2`
-**Edit Contact** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit Contact** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [evt/EVENT_INDEX]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **List Contact** | `list`
 **List Event** | `listevent`
+**List Contact From event** | `listevcontact`
 **Help** | `help`
 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -240,16 +240,18 @@ _Details coming soon ..._
 
 Action | Format, Examples
 --------|------------------
-**Add Contact** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [evt/EVENT_INDEX] …​` <br> e.g., `add n/Alex Yeoh p/89028392 e/alex@email.com a/Blk 142 Apple Street 23 evt/1`
-**Add Event** | `addevent ev/EVENT from/DATETIME to/DATETIME` <br> e.g., `addevent ev/Wedding Dinner from/01-05-2023 17:00 to/01-05-2023 21:00`
+**Add Contact** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [ev/EVENT_INDEX] …​` <br> e.g., `add n/Alex Yeoh p/89028392 e/alex@email.com a/Blk 142 Apple Street 23 evt/1`
+**Add Event** | `addevent ev/EVENT_NAME from/DATETIME to/DATETIME` <br> e.g., `addevent ev/Wedding Dinner from/01-05-2023 17:00 to/01-05-2023 21:00`
 **Clear** | `clear`
 **Delete Contact** | `delete INDEX`<br> e.g., `delete 3`
-**Delete Event** | `delevent EVENTINDEX` <br> e.g., `delevent 2`
+**Delete Event** | `delevent EVENT_INDEX` <br> e.g., `delevent 2`
 **Edit Contact** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [evt/EVENT_INDEX]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit Event** | `editevent EVENT_INDEX [ev/EVENT_NAME] [from/DATETIME] [to/DATETIME]​`<br> e.g.,`editevent 1 ev/Birthday Party from/17-07-2023 12:00`
 **List Contact** | `list`
 **List Event** | `listevent`
 **List Contact From event** | `listevcontact`
 **Help** | `help`
+
 
 
 

--- a/src/main/java/seedu/address/logic/commands/ListEvContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListEvContactCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+import seedu.address.model.person.EventSetContainsEventPredicate;
+
+/**
+ * Lists all persons with the target event in their event sets.
+ */
+public class ListEvContactCommand extends Command {
+    public static final String COMMAND_WORD = "listevcontact";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": List all the contacts from an event identified by it's index number\n"
+            + "Parameters: EVENT_INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_LIST_EVENT_CONTACT_SUCCESS = "Listed all contacts from the event : %1$s";
+
+    private final Index targetIndex;
+    private EventSetContainsEventPredicate predicate;
+
+    public ListEvContactCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Event> lastShownEventList = model.getFilteredEventList();
+
+        if (targetIndex.getZeroBased() >= lastShownEventList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+        }
+
+        Event targetEvent = lastShownEventList.get(targetIndex.getZeroBased());
+        predicate = new EventSetContainsEventPredicate(targetEvent);
+        model.updateFilteredPersonList(predicate);
+
+        return new CommandResult(String.format(MESSAGE_LIST_EVENT_CONTACT_SUCCESS, targetEvent));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListEvContactCommand // instanceof handles nulls
+                && targetIndex.equals(((ListEvContactCommand) other).targetIndex)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListEvContactCommand;
 import seedu.address.logic.commands.ListEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case DelEventCommand.COMMAND_WORD:
             return new DelEventCommandParser().parse(arguments);
+
+        case ListEvContactCommand.COMMAND_WORD:
+            return new ListEvContactCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ListEvContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListEvContactCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ListEvContactCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListEvContactCommand object
+ */
+public class ListEvContactCommandParser implements Parser<ListEvContactCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListEvContactCommand
+     * and returns a ListEvContact object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListEvContactCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ListEvContactCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListEvContactCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ListEvContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListEvContactCommandParser.java
@@ -12,7 +12,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class ListEvContactCommandParser implements Parser<ListEvContactCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the ListEvContactCommand
-     * and returns a ListEvContact object for execution.
+     * and returns a ListEvContactCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListEvContactCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/model/person/EventSetContainsEventPredicate.java
+++ b/src/main/java/seedu/address/model/person/EventSetContainsEventPredicate.java
@@ -1,0 +1,27 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.model.event.Event;
+
+/**
+ * Tests if a {@code Person}'s {@code EventSet} contains target event.
+ */
+public class EventSetContainsEventPredicate implements Predicate<Person> {
+    private final Event targetEvent;
+    public EventSetContainsEventPredicate(Event targetEvent) {
+        this.targetEvent = targetEvent;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getEventSet().contains(targetEvent);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EventSetContainsEventPredicate // instanceof handles nulls
+                && targetEvent.equals(((EventSetContainsEventPredicate) other).targetEvent)); // state check
+    }
+}

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -3,11 +3,13 @@
     "name": "Valid Person",
     "phone": "9482424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "eventSet": [ ]
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "eventSet": [ ]
   } ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -3,6 +3,7 @@
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "eventSet": [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -3,7 +3,8 @@
     "name": "Hans Muster",
     "phone": "9482424",
     "email": "invalid@email!3e",
-    "address": "4th street"
+    "address": "4th street",
+    "eventSet" : [ ]
   } ],
   "events" : [ {
     "eventName" : "Wedding Dinner",

--- a/src/test/java/seedu/address/logic/commands/ListEventContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListEventContactCommandTest.java
@@ -1,0 +1,129 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showEventAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_EVENT;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Event;
+import seedu.address.model.person.EventSetContainsEventPredicate;
+
+public class ListEventContactCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredListAndMultiplePersonListed_success() {
+        Event targetEvent = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        ListEvContactCommand listEvContactCommand = new ListEvContactCommand(INDEX_FIRST_EVENT);
+
+        String expectedMessage = String.format(ListEvContactCommand.MESSAGE_LIST_EVENT_CONTACT_SUCCESS, targetEvent);
+
+        EventSetContainsEventPredicate predicate = new EventSetContainsEventPredicate(targetEvent);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(listEvContactCommand, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredListAndNoPersonListed_success() {
+        Event targetEvent = model.getFilteredEventList().get(INDEX_THIRD_EVENT.getZeroBased());
+        ListEvContactCommand listEvContactCommand = new ListEvContactCommand(INDEX_THIRD_EVENT);
+
+        String expectedMessage = String.format(ListEvContactCommand.MESSAGE_LIST_EVENT_CONTACT_SUCCESS, targetEvent);
+
+        EventSetContainsEventPredicate predicate = new EventSetContainsEventPredicate(targetEvent);
+        expectedModel.updateFilteredPersonList(predicate);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(listEvContactCommand, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEventList().size() + 1);
+        ListEvContactCommand listEvContactCommand = new ListEvContactCommand(outOfBoundIndex);
+
+        assertCommandFailure(listEvContactCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredListAndMultiplePersonListed_success() {
+        showEventAtIndex(model, INDEX_FIRST_EVENT);
+        showEventAtIndex(expectedModel, INDEX_FIRST_EVENT);
+
+        Event targetEvent = model.getFilteredEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        ListEvContactCommand listEvContactCommand = new ListEvContactCommand(INDEX_FIRST_EVENT);
+
+        String expectedMessage = String.format(ListEvContactCommand.MESSAGE_LIST_EVENT_CONTACT_SUCCESS, targetEvent);
+
+        EventSetContainsEventPredicate predicate = new EventSetContainsEventPredicate(targetEvent);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(listEvContactCommand, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showEventAtIndex(model, INDEX_FIRST_EVENT);
+
+        Index outOfBoundIndex = INDEX_SECOND_EVENT;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getEventList().size());
+
+        ListEvContactCommand listEvContactCommand = new ListEvContactCommand(outOfBoundIndex);
+
+        assertCommandFailure(listEvContactCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        ListEvContactCommand listEvContactFirstCommand = new ListEvContactCommand(INDEX_FIRST_EVENT);
+        ListEvContactCommand listEvContactSecondCommand = new ListEvContactCommand(INDEX_SECOND_EVENT);
+
+        // same object -> returns true
+        assertTrue(listEvContactFirstCommand.equals(listEvContactFirstCommand));
+
+        // same values -> returns true
+        ListEvContactCommand listEvContactFirstCommandCopy = new ListEvContactCommand(INDEX_FIRST_EVENT);
+        assertTrue(listEvContactFirstCommand.equals(listEvContactFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(listEvContactFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(listEvContactFirstCommand.equals(null));
+
+        // different event and person -> returns false
+        assertFalse(listEvContactFirstCommand.equals(listEvContactSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no event.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+
+        assertTrue(model.getFilteredPersonList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,6 +27,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListEvContactCommand;
 import seedu.address.logic.commands.ListEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Event;
@@ -117,6 +118,13 @@ public class AddressBookParserTest {
         DelEventCommand command = (DelEventCommand) parser.parseCommand(
                 DelEventCommand.COMMAND_WORD + " " + INDEX_FIRST_EVENT.getOneBased());
         assertEquals(new DelEventCommand(INDEX_FIRST_EVENT), command);
+    }
+
+    @Test
+    public void parseCommand_listEvContact() throws Exception {
+        ListEvContactCommand command = (ListEvContactCommand) parser.parseCommand(
+                ListEvContactCommand.COMMAND_WORD + " " + INDEX_FIRST_EVENT.getOneBased());
+        assertEquals(new ListEvContactCommand(INDEX_FIRST_EVENT), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ListEventContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListEventContactCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ListEvContactCommand;
+
+public class ListEventContactCommandParserTest {
+    private ListEvContactCommandParser parser = new ListEvContactCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsListEvContactCommand() {
+        assertParseSuccess(parser, "1", new ListEvContactCommand(INDEX_FIRST_EVENT));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListEvContactCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListEvContactCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/person/EventSetContainsEventPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EventSetContainsEventPredicateTest.java
@@ -45,7 +45,7 @@ public class EventSetContainsEventPredicateTest {
     }
 
     @Test
-    public void test_nameDoesNotContainKeywords_returnsFalse() {
+    public void test_eventSetDoesNotContainEvent_returnsFalse() {
         // Zero event
         EventSetContainsEventPredicate predicate = new EventSetContainsEventPredicate(null);
         assertFalse(predicate.test(new PersonBuilder().withEventSet(WEDDING_DINNER).build()));

--- a/src/test/java/seedu/address/model/person/EventSetContainsEventPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EventSetContainsEventPredicateTest.java
@@ -1,0 +1,57 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalEvents.CARNIVAL;
+import static seedu.address.testutil.TypicalEvents.WEDDING_DINNER;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.event.Event;
+import seedu.address.testutil.PersonBuilder;
+
+public class EventSetContainsEventPredicateTest {
+    @Test
+    public void equals() {
+        Event firstPredicateTargetEvent = WEDDING_DINNER;
+        Event secondPredicateTargetEvent = CARNIVAL;
+
+        EventSetContainsEventPredicate firstPredicate = new EventSetContainsEventPredicate(firstPredicateTargetEvent);
+        EventSetContainsEventPredicate secondPredicate = new EventSetContainsEventPredicate(secondPredicateTargetEvent);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EventSetContainsEventPredicate firstPredicateCopy =
+                new EventSetContainsEventPredicate(firstPredicateTargetEvent);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different event -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_personEventSetContainsEvent_returnsTrue() {
+        EventSetContainsEventPredicate predicate = new EventSetContainsEventPredicate(WEDDING_DINNER);
+        assertTrue(predicate.test(new PersonBuilder().withEventSet(WEDDING_DINNER).build()));
+
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero event
+        EventSetContainsEventPredicate predicate = new EventSetContainsEventPredicate(null);
+        assertFalse(predicate.test(new PersonBuilder().withEventSet(WEDDING_DINNER).build()));
+
+        // Non-matching event set
+        predicate = new EventSetContainsEventPredicate(CARNIVAL);
+        assertFalse(predicate.test(new PersonBuilder().withEventSet(WEDDING_DINNER).build()));
+    }
+}


### PR DESCRIPTION
Add the list contacts from event feature 
- The command for this feature is listevcontact followed by an event index 
- All the persons whose event set contains the specified event in the address book will be listed, not just the currently filtered list of persons shown on the UI
- Only the list of persons featured on the UI will be updated, the list of events on the UI will not be modified 

