### PR TITLE
Add findevent feature

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,5 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_EVENTS_LISTED_OVERVIEW = "%1$d events listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindEventCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.event.EventNameContainsKeywordsPredicate;
+
+
+/**
+ * Finds and lists all events in address book whose name contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindEventCommand extends Command {
+
+    public static final String COMMAND_WORD = "findevent";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all events whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + "Black Pink World Tour [Born Pink] Singapore";
+
+    private final EventNameContainsKeywordsPredicate predicate;
+
+    public FindEventCommand(EventNameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredEventList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_EVENTS_LISTED_OVERVIEW, model.getFilteredEventList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindEventCommand // instanceof handles nulls
+                && predicate.equals(((FindEventCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditEventCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindEventCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListEvContactCommand;
@@ -66,6 +67,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case FindEventCommand.COMMAND_WORD:
+            return new FindEventCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/FindEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindEventCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.EventNameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindEventCommand object
+ */
+public class FindEventCommandParser implements Parser<FindEventCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindEventCommand
+     * and returns a FindEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindEventCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindEventCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindEventCommand(new EventNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -54,7 +54,11 @@ public class SampleDataUtil {
                     new DateTime("11-03-2023 19:00")),
             new Event(new EventName("Louis Tomlinson: Faith In The Future World Tour"),
                     new DateTime("27-04-2023 19:30"),
-                    new DateTime("27-04-2023 21:30"))
+                    new DateTime("27-04-2023 21:30")),
+            new Event(new EventName("Concert A"), new DateTime("01-05-2023 17:00"),
+                new DateTime("01-05-2023 18:00")),
+            new Event(new EventName("Concert B"), new DateTime("02-05-2023 17:00"),
+                 new DateTime("02-05-2023 18:00"))
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -46,8 +46,15 @@ public class SampleDataUtil {
 
     public static Event[] getSampleEvents() {
         return new Event[] {
-            new Event(new EventName("Concert A"), new DateTime("01-05-2023 17:00"), new DateTime("01-05-2023 18:00")),
-            new Event(new EventName("Concert B"), new DateTime("02-05-2023 17:00"), new DateTime("02-05-2023 18:00"))
+            new Event(new EventName("BLACKPINK World Tour - Born Pink"),
+                    new DateTime("13-05-2023 19:30"),
+                    new DateTime("13-05-2023 21:30")),
+            new Event(new EventName("Disney On Ice presents Mickey and Friends"),
+                    new DateTime("11-03-2023 17:00"),
+                    new DateTime("11-03-2023 19:00")),
+            new Event(new EventName("Louis Tomlinson: Faith In The Future World Tour"),
+                    new DateTime("27-04-2023 19:30"),
+                    new DateTime("27-04-2023 21:30"))
         };
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -61,7 +61,19 @@
   } ],
   "events" : [ {
     "eventName" : "Wedding Dinner",
-    "startDateTime" : "01-05-2023 17:00",
-    "endDateTime" : "01-05-2023 21:00"
-  } ]
+    "startDateTime" : "01-01-2024 19:00",
+    "endDateTime" : "01-01-2024 22:00"
+  }, {
+    "eventName" : "Carnival",
+    "startDateTime" : "17-07-2023 12:00",
+    "endDateTime" : "21-07-2023 22:00"
+  }, {
+    "eventName" : "Company ABC Sports Day",
+    "startDateTime" : "03-03-2024 09:00",
+    "endDateTime" : "03-03-2024 18:00"
+  }, {
+    "eventName" : "CEO's 50th birthday party",
+    "startDateTime" : "03-08-2023 15:00",
+    "endDateTime" : "03-08-2023 21:00"
+  }]
 }

--- a/src/test/java/seedu/address/logic/commands/FindEventTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindEventTest.java
@@ -51,7 +51,7 @@ public class FindEventTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different event -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 

--- a/src/test/java/seedu/address/logic/commands/FindEventTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindEventTest.java
@@ -1,0 +1,84 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_EVENTS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalEvents.CARNIVAL;
+import static seedu.address.testutil.TypicalEvents.SPORTS_DAY;
+import static seedu.address.testutil.TypicalEvents.WEDDING_DINNER;
+import static seedu.address.testutil.TypicalEvents.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.EventNameContainsKeywordsPredicate;
+
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindEventCommand}.
+ */
+public class FindEventTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        EventNameContainsKeywordsPredicate firstPredicate =
+                new EventNameContainsKeywordsPredicate(Collections.singletonList("first"));
+        EventNameContainsKeywordsPredicate secondPredicate =
+                new EventNameContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindEventCommand findFirstCommand = new FindEventCommand(firstPredicate);
+        FindEventCommand findSecondCommand = new FindEventCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindEventCommand findFirstCommandCopy = new FindEventCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noEventFound() {
+        String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 0);
+        EventNameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindEventCommand command = new FindEventCommand(predicate);
+        expectedModel.updateFilteredEventList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredEventList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleEventsFound() {
+        String expectedMessage = String.format(MESSAGE_EVENTS_LISTED_OVERVIEW, 3);
+        EventNameContainsKeywordsPredicate predicate = preparePredicate("wedding carnival sports");
+        FindEventCommand command = new FindEventCommand(predicate);
+        expectedModel.updateFilteredEventList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(WEDDING_DINNER, CARNIVAL, SPORTS_DAY), model.getFilteredEventList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code EventNameContainsKeywordsPredicate}.
+     */
+    private EventNameContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new EventNameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindEventCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindEventCommand;
+import seedu.address.model.event.EventNameContainsKeywordsPredicate;
+public class FindEventCommandParserTest {
+
+    private FindEventCommandParser parser = new FindEventCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindEventCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindEventCommand() {
+        // no leading and trailing whitespaces
+        FindEventCommand expectedFindEventCommand =
+                new FindEventCommand(new EventNameContainsKeywordsPredicate(Arrays.asList("Alpaca", "Bacon")));
+        System.out.println(expectedFindEventCommand.toString());
+        assertParseSuccess(parser, "Alpaca Bacon", expectedFindEventCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Alpaca \n \t Bacon  \t", expectedFindEventCommand);
+    }
+
+}


### PR DESCRIPTION
This PR adds the FindEventCommand class and the FindEventCommandParser class.

The `findevent` command allows users to search for events in the event list by keyword(s) specified in the command. It returns a list of events that match the specified keywords. This implementation is almost identical to the existing find command in the addressbook.

To try out this command, use `findevent ev/NAME_OF_EVENT`.