### PR TITLE
Add listall command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAllCommand.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EVENTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import seedu.address.model.Model;
+
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class ListAllCommand extends Command {
+
+    public static final String COMMAND_WORD = "listall";
+
+    public static final String MESSAGE_SUCCESS = "Listed all persons and events";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAllCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.Model;
 
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all persons and events in the address book to the user.
  */
 public class ListAllCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindEventCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListAllCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListEvContactCommand;
 import seedu.address.logic.commands.ListEventCommand;
@@ -91,6 +92,9 @@ public class AddressBookParser {
 
         case ListEvContactCommand.COMMAND_WORD:
             return new ListEvContactCommandParser().parse(arguments);
+
+        case ListAllCommand.COMMAND_WORD:
+            return new ListAllCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/test/java/seedu/address/logic/commands/ListAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAllCommandTest.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showEventAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListAllCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListAllCommand(), model, ListAllCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showEventAtIndex(model, INDEX_FIRST_EVENT);
+        assertCommandSuccess(new ListAllCommand(), model, ListAllCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}


### PR DESCRIPTION
This commit allows user to use the `listall` command which is designed to exhibit a comprehensive enumeration of all events and contacts stored in the address book. 

In essence, this command resets any filters applied and displays the default view of the address book.