### PR TITLE
Fix documentation and PPP draft

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -36,6 +36,8 @@ PlanEase is a **desktop app tailored for event planners to organise and manage t
 
    * `delete 3` : Deletes the 3rd contact shown in the current contact list.
 
+   * `findevent disney` : Displays events with the word 'disney' present in their event name as a keyword.
+
    * `delevent 1` : Deletes the 1st event shown in the current event list.
 
    * `clear` : Deletes all contacts and events.
@@ -65,7 +67,9 @@ PlanEase is a **desktop app tailored for event planners to organise and manage t
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
 * If a parameter is expected only once in the command but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
-  e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
+  e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken. 
+
+* As a result of the earlier feature, input by the user must not contain command prefix. This is to avoid misrepresentation of the command. e.g. `add n/Jane Lee p/62353535 e/janeizbored99@myspace.com a/123 n/Sapporo Shi` would be recognised as adding a contact with name, 'Sapporo Shi' because of `n/`.
 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
@@ -83,6 +87,7 @@ Adds a person to the address book and adds existing event to this person if even
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [evt/EVENT_INDEX]…​`
 
 * Person name cannot exceed 50 characters.
+* Person name is restricted to alphanumeric characters. 
 * The event index refers to the index number shown in the displayed event list.
 * The event index **must be a positive integer** 1, 2, 3, …​
 

--- a/docs/team/jerome-neo.md
+++ b/docs/team/jerome-neo.md
@@ -11,34 +11,39 @@ This application helps to streamline the process of searching for stakeholders' 
 
 Given below are my contributions to the project.
 
-* **New Feature**: to be added soon
-  * What it does: to be added soon
-  * Justification: to be added soon
-  * Highlights: to be added soon
-  * Credits: to be added soon
+* **New Feature**: Augmented the existing storage to accept event objects as well event objects stored in each contact. ([#36](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/36))
+  * What it does: Allows the rest of the features to save the events that we created in the address book.
+  * Justification: This feature is crucial as it supports the additional data type that we implemented in this project.
 
-* **New Feature**: to be added soon
-  * What it does: to be added soon
-  * Justification: to be added soon
-  * Highlights: to be added soon
-  * Credits: to be added soon
+* **New Feature**: Add checking of valid event dates in `addevent`. ([#36](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/36), [#37](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/37))
+  * What it does: It checks the event dates are of the valid range. The start date will have to be earlier than the end date.
+  * Justification: It is not logical to have an end date earlier than a start date.
+  * Highlights: This implementation also ensures that same date and time set to the data range is accepted for an event.
+
+* **New Feature**: Add searching features for events in `findevent`. ([#57](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/57))
+  * What it does: It looks for events with names containing the keywords that the user wants to match with.
+  * Justification: This is to cater to use cases where there are large number of events being stored in the list and the user may want to isolate the display of events to those events.
 
 * **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=jerome-neo&breakdown=true)
 
 * **Enhancements implemented**:
-  * to be added soon
+  * Reduce window white space which was present on macOS users. ([#51](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/51))
 
 * **Contributions to the Developer Guide**
-  * to be added soon
+  * Added `findevent` documentation as well as sequence diagrams. ([#63](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/63))
+  * Updated storage diagrams as well as class diagrams. ([#63](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/63))
 
 * **Contributions to the User Guide**
-  * to be added soon
+  * Update documentation for `listevent`. ([#30](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/30))
+  * Added examples for `findevent`.
+  * Improve explanation of naming restrictions.
 
 * **Contributions to team-based tasks**
-  * [Update team information and images](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/10)
+  * Update team information and images. ([#10](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/10))
+  * Added user stories to tp issue tracker.
 
 * **Review/mentoring contributions**
-  * to be added soon
+  * PRs reviewed (with useful comments): [#33](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/33), [#69](https://github.com/AY2223S2-CS2103-W16-3/tp/pull/69)
 
 * **Contributions beyond the project team**
-  * to be added soon
+  * Reported 10 bugs for: [PE-D Issues link](https://github.com/jerome-neo/ped/issues)


### PR DESCRIPTION
This commit adds additional fixes to the documentation from PE dry run. Namely, more explicit restrictions for contact names and use of addevent with command prefix within the inputs.

Additonally, this commit adds a draft for jerome-neo PPP.